### PR TITLE
Fix --prescan-world=disabled-force does not work

### DIFF
--- a/TileGenerator.h
+++ b/TileGenerator.h
@@ -258,7 +258,7 @@ private:
 	int m_heightScaleMinor;
 
 	DB *m_db;
-	bool m_generateNoPrefetch;
+	int m_generateNoPrefetch;
 	bool m_databaseFormatSet;
 	BlockPos::StrFormat m_databaseFormat;
 	std::string m_recommendedDatabaseFormat;


### PR DESCRIPTION
This would make `--disable-blocklist-prefetch=force` and `--prescan-world=disabled-force` work again.

Also fixes a compiler warning on MSVC.
