### PR TITLE
Fix various compiler warnings on MSVC

### DIFF
--- a/BlockPos.h
+++ b/BlockPos.h
@@ -145,8 +145,8 @@ public:
 	NodeCoordHashed(const BlockPos &pos) : NodeCoord(pos) { rehash(); }
 	NodeCoordHashed(const NodeCoord &coord) : NodeCoord(coord) { rehash(); }
 	void rehash(void) { m_hash = NodeCoord::hash(); }
-	unsigned hash(void) { rehash(); return m_hash; }
-	unsigned hash(void) const { return m_hash; }
+	unsigned hash(void) { rehash(); return static_cast<unsigned>(m_hash); }
+	unsigned hash(void) const { return static_cast<unsigned>(m_hash); }
 	bool operator==(const NodeCoordHashed &coord) const { if (m_hash != coord.m_hash) return false; return NodeCoord::operator==(coord); }
 	void operator=(const NodeCoord &coord) { NodeCoord::operator=(coord); rehash(); }
 	bool operator<(const NodeCoordHashed &coord) { return m_hash < coord.m_hash; }

--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -2215,7 +2215,7 @@ void TileGenerator::renderHeightScale()
 		gdImageLine(m_image, xBorderOffset + x, yBorderOffset + 8, xBorderOffset + x, yBorderOffset + borderBottom() - 20, color.to_libgd());
 
 		int iheight = int(height + (height > 0 ? 0.5 : -0.5));
-		int iheightMaj = int(iheight / major + (height > 0 ? 0.5 : -0.5)) * major;
+		int iheightMaj = int(iheight / major + (height > 0 ? 0.5 : -0.5) * major);
 		if (fabs(height - iheightMaj) <= height_step / 2 && (height - iheightMaj) > -height_step / 2) {
 			if (iheightMaj / int(major) % 2 == 1 && fabs(height) > 9999 && major / height_step < 56) {
 				// Maybe not enough room for the number. Draw a tick mark instead
@@ -2252,8 +2252,8 @@ void TileGenerator::renderPlayers(const std::string &inputPath)
 
 	PlayerAttributes players(inputPath);
 	for (PlayerAttributes::Players::iterator player = players.begin(); player != players.end(); ++player) {
-		int imageX = worldX2ImageX(player->x / 10);
-		int imageY = worldZ2ImageY(player->z / 10);
+		int imageX = worldX2ImageX(static_cast<int>(player->x / 10));
+		int imageY = worldZ2ImageY(static_cast<int>(player->z / 10));
 		std::string displayName = m_gdStringConv->convert(player->name);
 
 		gdImageArc(m_image, imageX, imageY, 5, 5, 0, 360, color);

--- a/ZlibDecompressor.cpp
+++ b/ZlibDecompressor.cpp
@@ -46,7 +46,7 @@ ustring ZlibDecompressor::decompress()
 	strm.zfree = Z_NULL;
 	strm.opaque = Z_NULL;
 	strm.next_in = Z_NULL;
-	strm.avail_in = size;
+	strm.avail_in = static_cast<uInt>(size);
 
 	if (inflateInit(&strm) != Z_OK) {
 		throw DecompressError(strm.msg);

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -497,7 +497,7 @@ static void orderCoordinateDimensions(NodeCoord &coord1, NodeCoord &coord2, int 
 // <x>,<y>@<angle>+<length>
 static bool parseGeometry(istream &is, NodeCoord &coord1, NodeCoord &coord2, NodeCoord &dimensions, bool &legacy, bool &centered, int n, FuzzyBool expectDimensions, int wildcard = 0)
 {
-	int pos;
+	std::streamoff pos;
 	pos = is.tellg();
 	legacy = false;
 
@@ -871,7 +871,7 @@ int main(int argc, char *argv[])
 					break;
 				case OPT_HEIGHTMAPYSCALE:
 					if (isdigit(optarg[0]) || ((optarg[0]=='-' || optarg[0]=='+') && isdigit(optarg[1]))) {
-						float scale = atof(optarg);
+						float scale = static_cast<float>(atof(optarg));
 						generator.setHeightMapYScale(scale);
 					}
 					else {

--- a/minetest-database.h
+++ b/minetest-database.h
@@ -31,12 +31,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  * It's a lot more complicated than it looks.
  */
 
-static inline int unsigned_to_signed(unsigned i, unsigned max_positive)
+static inline int unsigned_to_signed(int64_t i, unsigned max_positive)
 {
 	if (i < max_positive) {
-		return i;
+		return static_cast<int>(i);
 	} else {
-		return i - (max_positive * 2);
+		return static_cast<int>(i - (max_positive * 2));
 	}
 }
 

--- a/util.h
+++ b/util.h
@@ -6,9 +6,9 @@
 
 inline std::string strlower(const std::string &s)
 {
-	int l = s.length();
+	size_t l = s.length();
 	std::string sl = s;
-	for (int i = 0; i < l; i++)
+	for (size_t i = 0; i < l; i++)
 		sl[i] = tolower(sl[i]);
 	return sl;
 }


### PR DESCRIPTION
I tried to avoid casts wherever it was possible, but for some cases it wasn't. 
There are many C-like casts, maybe you should consider to replace them some day.

The only warnings that occur now are from leveldb or are about using c++11 functions instead of c++99 (even occurs in Microsofts libraries :laughing: )