### PR TITLE
Fix msvc compiler warnings

### DIFF
--- a/BlockPos.h
+++ b/BlockPos.h
@@ -145,8 +145,8 @@ public:
 	NodeCoordHashed(const BlockPos &pos) : NodeCoord(pos) { rehash(); }
 	NodeCoordHashed(const NodeCoord &coord) : NodeCoord(coord) { rehash(); }
 	void rehash(void) { m_hash = NodeCoord::hash(); }
-	unsigned hash(void) { rehash(); return m_hash; }
-	unsigned hash(void) const { return m_hash; }
+	size_t hash(void) { rehash(); return m_hash; }
+	size_t hash(void) const { return m_hash; }
 	bool operator==(const NodeCoordHashed &coord) const { if (m_hash != coord.m_hash) return false; return NodeCoord::operator==(coord); }
 	void operator=(const NodeCoord &coord) { NodeCoord::operator=(coord); rehash(); }
 	bool operator<(const NodeCoordHashed &coord) { return m_hash < coord.m_hash; }

--- a/MSVC/minetestmapper.vcxproj
+++ b/MSVC/minetestmapper.vcxproj
@@ -110,7 +110,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>D:\libs\gd\include;$(ProjectDir)dirent\include;$(ProjectDir)wingetopt\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -152,7 +152,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>D:\libs\gd\include;$(ProjectDir)dirent\include;$(ProjectDir)wingetopt\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/MSVC/minetestmapper.vcxproj
+++ b/MSVC/minetestmapper.vcxproj
@@ -130,7 +130,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>D:\libs\gd\include;$(ProjectDir)dirent\include;$(ProjectDir)wingetopt\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -152,7 +152,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>D:\libs\gd\include;$(ProjectDir)dirent\include;$(ProjectDir)wingetopt\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -2214,8 +2214,8 @@ void TileGenerator::renderHeightScale()
 		Color color = computeMapHeightColor(int(height + 0.5));
 		gdImageLine(m_image, xBorderOffset + x, yBorderOffset + 8, xBorderOffset + x, yBorderOffset + borderBottom() - 20, color.to_libgd());
 
-		int iheight = int(height + (height > 0 ? 0.5 : -0.5));
-		int iheightMaj = int(iheight / major + (height > 0 ? 0.5 : -0.5)) * major;
+		int iheight = static_cast<int>(height + (height > 0 ? 0.5 : -0.5));
+		int iheightMaj = static_cast<int>(trunc(iheight / major + (height > 0 ? 0.5 : -0.5)) * major);
 		if (fabs(height - iheightMaj) <= height_step / 2 && (height - iheightMaj) > -height_step / 2) {
 			if (iheightMaj / int(major) % 2 == 1 && fabs(height) > 9999 && major / height_step < 56) {
 				// Maybe not enough room for the number. Draw a tick mark instead
@@ -2252,8 +2252,8 @@ void TileGenerator::renderPlayers(const std::string &inputPath)
 
 	PlayerAttributes players(inputPath);
 	for (PlayerAttributes::Players::iterator player = players.begin(); player != players.end(); ++player) {
-		int imageX = worldX2ImageX(player->x / 10);
-		int imageY = worldZ2ImageY(player->z / 10);
+		int imageX = worldX2ImageX(static_cast<int>(player->x / 10));
+		int imageY = worldZ2ImageY(static_cast<int>(player->z / 10));
 		std::string displayName = m_gdStringConv->convert(player->name);
 
 		gdImageArc(m_image, imageX, imageY, 5, 5, 0, 360, color);

--- a/ZlibDecompressor.cpp
+++ b/ZlibDecompressor.cpp
@@ -46,7 +46,7 @@ ustring ZlibDecompressor::decompress()
 	strm.zfree = Z_NULL;
 	strm.opaque = Z_NULL;
 	strm.next_in = Z_NULL;
-	strm.avail_in = size;
+	strm.avail_in = static_cast<uInt>(size);
 
 	if (inflateInit(&strm) != Z_OK) {
 		throw DecompressError(strm.msg);

--- a/doc/build-instructions.rst
+++ b/doc/build-instructions.rst
@@ -232,14 +232,6 @@ Building Minetestmapper
 
 With everything set up, Minetestmapper can be built.
 
-Building for 64-bit may fail due to a `bug in snappy`__. If this happens,
-the following steps will solve this:
-
-1. Open ``packages\Snappy.1.1.1.7\lib\native\src\snappy.cc``
-2. Change line 955 from ``#ifndef WIN32`` to ``#ifndef _WIN32``
-
-__ https://bitbucket.org/robertvazan/snappy-visual-cpp/issues/1/snappycc-will-not-compile-on-windows-x64
-
 Debugging Minetestmapper
 ........................
 

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -49,6 +49,7 @@ using namespace std;
 #define DRAW_ARROW_LENGTH		10
 #define DRAW_ARROW_ANGLE		30
 
+
 // Will be replaced with the actual name and location of the executable (if found)
 string executableName = "minetestmapper";
 string executablePath;			// ONLY for use on windows
@@ -497,7 +498,7 @@ static void orderCoordinateDimensions(NodeCoord &coord1, NodeCoord &coord2, int 
 // <x>,<y>@<angle>+<length>
 static bool parseGeometry(istream &is, NodeCoord &coord1, NodeCoord &coord2, NodeCoord &dimensions, bool &legacy, bool &centered, int n, FuzzyBool expectDimensions, int wildcard = 0)
 {
-	int pos;
+	std::streamoff pos;
 	pos = is.tellg();
 	legacy = false;
 
@@ -871,7 +872,7 @@ int main(int argc, char *argv[])
 					break;
 				case OPT_HEIGHTMAPYSCALE:
 					if (isdigit(optarg[0]) || ((optarg[0]=='-' || optarg[0]=='+') && isdigit(optarg[1]))) {
-						float scale = atof(optarg);
+						float scale = static_cast<float>(atof(optarg));
 						generator.setHeightMapYScale(scale);
 					}
 					else {

--- a/minetest-database.h
+++ b/minetest-database.h
@@ -34,15 +34,15 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 static inline int unsigned_to_signed(unsigned i, unsigned max_positive)
 {
 	if (i < max_positive) {
-		return i;
+		return static_cast<int>(i);
 	} else {
-		return i - (max_positive * 2);
+		return static_cast<int>(i - (max_positive * 2));
 	}
 }
 
 
 // Modulo of a negative number does not work consistently in C
-static inline int64_t pythonmodulo(int64_t i, int16_t mod)
+static inline unsigned pythonmodulo(int64_t i, unsigned mod)
 {
 	if (i >= 0) {
 		return i % mod;

--- a/util.h
+++ b/util.h
@@ -6,9 +6,9 @@
 
 inline std::string strlower(const std::string &s)
 {
-	int l = s.length();
+	size_t l = s.length();
 	std::string sl = s;
-	for (int i = 0; i < l; i++)
+	for (size_t i = 0; i < l; i++)
 		sl[i] = tolower(sl[i]);
 	return sl;
 }


### PR DESCRIPTION
Fix compiler warnings on MSVC.
Work around the snappy bug.

There are no more warnings except `No standard charset converter defined for WIN32 - disabling conversion`
