### PR TITLE
Abstracting PaintEngine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ set(mapper_SRCS
 	BlockPos.cpp
 	mapper.cpp
 	CharEncodingConverter.cpp
+	PaintEngine_libgd.cpp
 	${MAPPER_SRCS_ICONV}
 )
 

--- a/MSVC/minetestmapper.vcxproj
+++ b/MSVC/minetestmapper.vcxproj
@@ -175,6 +175,8 @@
     <ClInclude Include="..\db-sqlite3.h" />
     <ClInclude Include="..\db.h" />
     <ClInclude Include="..\minetest-database.h" />
+    <ClInclude Include="..\PaintEngine.h" />
+    <ClInclude Include="..\PaintEngine_libgd.h" />
     <ClInclude Include="..\PixelAttributes.h" />
     <ClInclude Include="..\PlayerAttributes.h" />
     <ClInclude Include="..\porting.h" />
@@ -195,6 +197,7 @@
     <ClCompile Include="..\db-leveldb.cpp" />
     <ClCompile Include="..\db-sqlite3.cpp" />
     <ClCompile Include="..\mapper.cpp" />
+    <ClCompile Include="..\PaintEngine_libgd.cpp" />
     <ClCompile Include="..\PixelAttributes.cpp" />
     <ClCompile Include="..\PlayerAttributes.cpp" />
     <ClCompile Include="..\Settings.cpp" />

--- a/PaintEngine.h
+++ b/PaintEngine.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <string>
+
+#include "Color.h"
+
+class PaintEngine
+{
+public:
+	enum class Font{
+		Tiny, // 8px
+		Small, // 13px
+		MediumBold, // 13px bold
+		large, // 16px
+		Giant // 15px bold?
+	};
+	virtual ~PaintEngine() {};
+	virtual bool create(int w, int h) = 0;
+	virtual void fill(const Color &color) = 0;
+	virtual void drawText(int x, int y, Font font, const std::string &text, const Color &color) = 0;
+	virtual void drawChar(int x, int y, Font font, const char ch, const Color &color) = 0;
+	virtual void drawRect(int x1, int y1, int x2, int y2, const Color &color) = 0;
+	virtual void drawLine(int x1, int y1, int x2, int y2, const Color &color) = 0;
+	virtual void drawCircle(int x, int y, int r, const Color &color) = 0;
+	virtual void drawArc(int x, int y, int w, int h, int start, int end, const Color &color) = 0;
+	virtual void drawFilledRect(int x1, int y1, int x2, int y2, const Color &color) = 0;
+	virtual void drawPixel(int x, int y, const Color &color) = 0;
+	virtual bool save(const std::string &filename, const std::string &format, int quality) = 0;
+	virtual void clean() = 0;
+};

--- a/PaintEngine_libgd.cpp
+++ b/PaintEngine_libgd.cpp
@@ -1,0 +1,126 @@
+#include "PaintEngine_libgd.h"
+
+#include <sstream>
+
+#include <gdfontmb.h>
+#include <gdfontl.h>
+#include <gdfontg.h>
+#include <gdfonts.h>
+#include <gdfontt.h>
+
+
+PaintEngine_libgd::PaintEngine_libgd()
+{
+	// Libgd requires ISO8859-2 :-(
+	// Internally, we use UTF-8. Assume minetest does the same... (if not, it's probably broken)
+	gdStringConv = CharEncodingConverter::createStandardConverter("ISO8859-2", "UTF-8");
+}
+
+
+PaintEngine_libgd::~PaintEngine_libgd()
+{
+	clean();
+}
+
+bool PaintEngine_libgd::create(int w, int h)
+{
+	width = w;
+	height = h;
+	image = gdImageCreateTrueColor(w, h);
+	return image != nullptr;
+}
+
+void PaintEngine_libgd::fill(const Color &color)
+{
+	gdImageFilledRectangle(image, 0, 0, width - 1, height - 1, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawText(int x, int y, Font font, const std::string &text, const Color &color)
+{
+	const std::string str = gdStringConv->convert(text);
+	gdImageString(image, getGdFont(font), x, y, 
+		reinterpret_cast<unsigned char *>(const_cast<char *>(str.c_str())), color.to_libgd());
+}
+
+void PaintEngine_libgd::drawChar(int x, int y, Font font, char ch, const Color &color)
+{
+
+	gdImageChar(image, getGdFont(font), x, y, ch, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawRect(int x1, int y1, int x2, int y2, const Color &color)
+{
+	gdImageRectangle(image, x1, y1, x2, y2, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawLine(int x1, int y1, int x2, int y2, const Color &color)
+{
+	gdImageLine(image, x1, y1, x2, y2, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawCircle(int x, int y, int r, const Color &color)
+{
+	gdImageArc(image, x, y, r, r, 0, 360, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawArc(int x, int y, int w, int h, int start, int end, const Color &color)
+{
+	gdImageArc(image, x, y, w, h, start, end, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawFilledRect(int x1, int y1, int x2, int y2, const Color &color)
+{
+	gdImageFilledRectangle(image, x1, y1, x2, y2, color.to_libgd());
+}
+
+void PaintEngine_libgd::drawPixel(int x, int y, const Color &color)
+{
+	image->tpixels[y][x] = color.to_libgd();
+}
+
+bool PaintEngine_libgd::save(const std::string & filename, const std::string & format, int quality)
+{
+	FILE *out;
+	out = fopen(filename.c_str(), "wb");
+	if (!out) {
+		std::ostringstream oss;
+		oss << "Error opening '" << filename << "': " << std::strerror(errno);
+		throw std::runtime_error(oss.str());
+	}
+	gdImagePng(image, out);
+	fclose(out);
+	gdImageDestroy(image);
+	return true;
+}
+
+void PaintEngine_libgd::clean()
+{
+	gdImageDestroy(image);
+}
+
+gdFontPtr PaintEngine_libgd::getGdFont(Font font)
+{
+	gdFontPtr f;
+	switch (font)
+	{
+	case PaintEngine::Font::Tiny:
+		f = gdFontGetTiny();
+		break;
+	case PaintEngine::Font::Small:
+		f = gdFontGetSmall();
+		break;
+	case PaintEngine::Font::MediumBold:
+		f = gdFontGetMediumBold();
+		break;
+	case PaintEngine::Font::large:
+		f = gdFontGetLarge();
+		break;
+	case PaintEngine::Font::Giant:
+		f = gdFontGetGiant();
+		break;
+	default:
+		f = gdFontGetSmall();
+		break;
+	}
+	return f;
+}

--- a/PaintEngine_libgd.h
+++ b/PaintEngine_libgd.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "paintEngine.h"
+#include "CharEncodingConverter.h"
+#include <gd.h>
+
+class PaintEngine_libgd :
+	public PaintEngine
+{
+public:
+	PaintEngine_libgd();
+	~PaintEngine_libgd();
+	bool create(int w, int h);
+	void fill(const Color &color);
+	void drawText(int x, int y, Font font, const std::string &text, const Color &color);
+	void drawChar(int x, int y, Font font, char ch, const Color &color);
+	void drawRect(int x1, int y1, int x2, int y2, const Color &color);
+	void drawLine(int x1, int y1, int x2, int y2, const Color &color);
+	void drawCircle(int x, int y, int r, const Color &color);
+	void drawArc(int x, int y, int w, int h, int start, int end, const Color &color);
+	void drawFilledRect(int x1, int y1, int x2, int y2, const Color &color);
+	void drawPixel(int x, int y, const Color &color);
+	bool save(const std::string &filename, const std::string &format, int quality);
+	void clean();
+private:
+	gdImagePtr image = nullptr;
+	int width = 0;
+	int height = 0;
+	gdFontPtr getGdFont(Font font);
+	CharEncodingConverter *gdStringConv = nullptr;
+};
+

--- a/TileGenerator.h
+++ b/TileGenerator.h
@@ -25,12 +25,12 @@
 #include <string>
 #include <iostream>
 #include <sstream>
-#include "CharEncodingConverter.h"
 #include "types.h"
 #include "PixelAttributes.h"
 #include "BlockPos.h"
 #include "Color.h"
 #include "db.h"
+#include "PaintEngine.h"
 
 #define TILESIZE_CHUNK			(INT_MIN)
 #define TILECENTER_AT_WORLDCENTER	(INT_MAX)
@@ -264,7 +264,7 @@ private:
 	std::string m_recommendedDatabaseFormat;
 	long long m_databaseFormatFound[BlockPos::STRFORMAT_MAX];
 	bool m_reportDatabaseFormat;
-	gdImagePtr m_image;
+	PaintEngine *paintEngine = nullptr;
 	PixelAttributes m_blockPixelAttributes;
 	PixelAttributes m_blockPixelAttributesScaled;
 	int m_xMin;
@@ -319,8 +319,6 @@ private:
 	uint16_t m_readedPixels[16];
 	std::set<std::string> m_unknownNodes;
 	std::vector<DrawObject> m_drawObjects;
-
-	CharEncodingConverter *m_gdStringConv;
 }; /* -----  end of class TileGenerator  ----- */
 
 #endif /* end of include guard: TILEGENERATOR_H_JJNUCARH */

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -23,6 +23,7 @@
 #include "PixelAttributes.h"
 #include "util.h"
 #include "db-sqlite3.h"
+#include "CharEncodingConverter.h"
 
 using namespace std;
 


### PR DESCRIPTION
This PR abstracts libgd to a PaintEngine class. This might be a little bit slower (if even) but it allows easier switching to a other drawing library.